### PR TITLE
Updating container css, full width buttons on tablet screen down

### DIFF
--- a/index.css
+++ b/index.css
@@ -46,16 +46,24 @@ html > body {
 .qedit #menu-handle > .login-image { height: 8ex; }
 
 .container {
-  margin: 5px;
+  max-width: 1220px;
+  margin-left: auto;
+  margin-right: auto;
   text-align: center;
   align-self: center;
 }
 
 #buttons {
-  /* text-indent: 3em; */
   margin-top: 6ex;
   overflow-y: hidden;
   transition: height 0.4s;
+}
+
+@media only screen and (max-width: 768px) {
+  #buttons {
+    display: flex;
+    flex-direction: column;
+  }
 }
 
 .btn, .inp {


### PR DESCRIPTION
This PR updates the CSS for containers to enforce a max width for large screens, using margin-auto to center containers in the screen.

It also adjusts the layout of buttons so that they appear full width on devices smaller than 768px (tablets), to make it easier to click on an option.

Buttons on phone:
<img width="425" alt="Screen Shot 2020-02-04 at 3 55 04 PM" src="https://user-images.githubusercontent.com/11272489/73786612-a265b700-4767-11ea-82d0-f49903974fcb.png">

Buttons on tablet:
<img width="795" alt="Screen Shot 2020-02-04 at 3 54 58 PM" src="https://user-images.githubusercontent.com/11272489/73786642-b27d9680-4767-11ea-87f8-8f3411848977.png">

Buttons on laptop:
<img width="1059" alt="Screen Shot 2020-02-04 at 3 55 10 PM" src="https://user-images.githubusercontent.com/11272489/73786687-caedb100-4767-11ea-9f52-99e40b2611fa.png">

Container on large screen:
<img width="1330" alt="Screen Shot 2020-02-04 at 3 55 26 PM" src="https://user-images.githubusercontent.com/11272489/73786672-c1644900-4767-11ea-8c5b-ceaccd6e2435.png">

